### PR TITLE
fix: harden configuration and package imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,25 @@ git clone https://github.com/yanismiraoui/cs224v-project.git
 pip install -r requirements.txt
 ```
 
-3. Set your Together API key in a `secrets.toml` file.
+3. Configure credentials. Prefer environment variables for deployment/CI:
+```bash
+export TOGETHER_API_KEY="your-together-api-key"
+# Optional: enables feedback collection in the Streamlit app
+export POSTGRES_DB="postgresql://user:password@host:5432/database"
+```
 
-4. Run the Streamlit app:
+For local development, you can alternatively create a root-level `secrets.toml`:
+```toml
+TOGETHER_API_KEY = "your-together-api-key"
+POSTGRES_DB = "postgresql://user:password@host:5432/database" # optional
+```
+
+4. Run the tests:
+```bash
+python -m pytest -q
+```
+
+5. Run the Streamlit app:
 ```bash
 streamlit run langchain_agents/streamlit_app.py
 ```

--- a/langchain_agents/__init__.py
+++ b/langchain_agents/__init__.py
@@ -1,0 +1,1 @@
+"""RecruiTree LangChain agents package."""

--- a/langchain_agents/agent.py
+++ b/langchain_agents/agent.py
@@ -1,16 +1,27 @@
 from langchain.agents import AgentExecutor, create_structured_chat_agent
 from langchain.memory import ConversationBufferMemory
-from tools import (
-    route_website_request,
-    optimize_github_profile,
-    publish_to_github_pages,
-    get_current_github_readme,
-    generate_github_readme,
-    publish_to_github_readme
-)
 from langchain_core.prompts import ChatPromptTemplate
 from typing import Optional, Dict, Any, List, Union
-from custom_together_llm import TogetherLLM
+try:
+    from .tools import (
+        route_website_request,
+        optimize_github_profile,
+        publish_to_github_pages,
+        get_current_github_readme,
+        generate_github_readme,
+        publish_to_github_readme,
+    )
+    from .custom_together_llm import TogetherLLM
+except ImportError:  # Allows running from langchain_agents/ directly
+    from tools import (
+        route_website_request,
+        optimize_github_profile,
+        publish_to_github_pages,
+        get_current_github_readme,
+        generate_github_readme,
+        publish_to_github_readme,
+    )
+    from custom_together_llm import TogetherLLM
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -128,7 +139,10 @@ class JobApplicationAgent:
     def __init__(self):
         """Initialize the job application agent with LangChain components."""
         setup_logging()  # Initialize logging
-        self.llm = TogetherLLM(temperature=0.1)
+        self.llm = TogetherLLM(
+            temperature=0.1,
+            response_format={"type": "json_object"},
+        )
         
         # Add action history attribute
         self.action_history: List[Dict[str, Any]] = []

--- a/langchain_agents/agents/base_page_generator.py
+++ b/langchain_agents/agents/base_page_generator.py
@@ -1,4 +1,7 @@
-from custom_together_llm import TogetherLLM
+try:
+    from ..custom_together_llm import TogetherLLM
+except ImportError:  # Allows running from langchain_agents/ directly
+    from custom_together_llm import TogetherLLM
 from typing import List
 import os
 

--- a/langchain_agents/agents/education_page_generator.py
+++ b/langchain_agents/agents/education_page_generator.py
@@ -1,4 +1,7 @@
-from custom_together_llm import TogetherLLM
+try:
+    from ..custom_together_llm import TogetherLLM
+except ImportError:  # Allows running from langchain_agents/ directly
+    from custom_together_llm import TogetherLLM
 from typing import Optional, Dict, Union, Any, List
 import os
 import json

--- a/langchain_agents/agents/home_screen_generator.py
+++ b/langchain_agents/agents/home_screen_generator.py
@@ -1,4 +1,7 @@
-from custom_together_llm import TogetherLLM
+try:
+    from ..custom_together_llm import TogetherLLM
+except ImportError:  # Allows running from langchain_agents/ directly
+    from custom_together_llm import TogetherLLM
 from typing import Optional, Dict, Union, Any, List
 from langchain_core.prompts import ChatPromptTemplate
 import json

--- a/langchain_agents/agents/page_router.py
+++ b/langchain_agents/agents/page_router.py
@@ -1,6 +1,9 @@
 from typing import Dict, Any, Optional, List
 import json
-from custom_together_llm import TogetherLLM
+try:
+    from ..custom_together_llm import TogetherLLM
+except ImportError:  # Allows running from langchain_agents/ directly
+    from custom_together_llm import TogetherLLM
 from .base_page_generator import BasePageGenerator
 from .home_screen_generator import HomeScreenGenerator
 from .education_page_generator import EducationPageGenerator

--- a/langchain_agents/config.py
+++ b/langchain_agents/config.py
@@ -1,0 +1,68 @@
+"""Configuration helpers for local development and deployed apps.
+
+Secrets can be supplied either as environment variables (recommended for
+production) or via the repository's legacy ``secrets.toml`` file for local
+Streamlit runs.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    import toml as tomllib  # type: ignore[no-redef]
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SECRETS_PATH = PROJECT_ROOT / "secrets.toml"
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when a required configuration value is missing."""
+
+
+def load_secrets(secrets_path: str | os.PathLike[str] | None = None) -> Mapping[str, Any]:
+    """Load TOML secrets from disk.
+
+    Missing files are treated as an empty mapping so callers can rely on
+    environment variables without creating a local ``secrets.toml``.
+    """
+
+    path = Path(secrets_path) if secrets_path is not None else DEFAULT_SECRETS_PATH
+    if not path.exists():
+        return {}
+    return tomllib.loads(path.read_text())
+
+
+def get_secret(
+    name: str,
+    *,
+    secrets_path: str | os.PathLike[str] | None = None,
+    required: bool = True,
+) -> str | None:
+    """Return a secret from the environment or ``secrets.toml``.
+
+    Environment variables intentionally take precedence so deployment
+    platforms and CI can inject credentials without writing secret files.
+    """
+
+    env_value = os.getenv(name)
+    if env_value:
+        return env_value
+
+    secrets = load_secrets(secrets_path)
+    file_value = secrets.get(name)
+    if file_value:
+        return str(file_value)
+
+    if required:
+        path = Path(secrets_path) if secrets_path is not None else DEFAULT_SECRETS_PATH
+        raise ConfigurationError(
+            f"Missing required secret {name!r}. Set it as an environment variable "
+            f"or add it to secrets.toml at {path}."
+        )
+    return None

--- a/langchain_agents/custom_together_llm.py
+++ b/langchain_agents/custom_together_llm.py
@@ -3,15 +3,25 @@ from langchain.llms.base import LLM
 from langchain.callbacks.manager import CallbackManagerForLLMRun
 from together import Together
 import os
-import toml
+
+try:
+    from .config import get_secret
+except ImportError:  # Allows running files directly from langchain_agents/
+    from config import get_secret
 
 class TogetherLLM(LLM):
     """Custom LangChain LLM wrapper for Together AI."""
     
-    model_name: str = "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo" #"meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo" #"meta-llama/Llama-3.2-3B-Instruct-Turbo" #"meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
+    model_name: str = "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
     temperature: float = 0.1
+    max_tokens: Optional[int] = None
+    response_format: Optional[dict] = None
     
     def __init__(self, **kwargs):
+        # Older call sites used ``model=...``; normalize it to the field LangChain
+        # expects so those pages keep working.
+        if "model" in kwargs and "model_name" not in kwargs:
+            kwargs["model_name"] = kwargs.pop("model")
         super().__init__(**kwargs)
     
     @property
@@ -27,25 +37,25 @@ class TogetherLLM(LLM):
     ) -> str:
         """Execute the LLM call."""
 
-        # Read API key from secrets.toml
-        secrets_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'secrets.toml')
-        secrets = toml.load(secrets_path)
-        os.environ['TOGETHER_API_KEY'] = secrets['TOGETHER_API_KEY']
+        api_key = get_secret('TOGETHER_API_KEY')
+        if api_key is None:  # Defensive for type checkers; required=True raises first.
+            raise ValueError("TOGETHER_API_KEY is required")
+        os.environ['TOGETHER_API_KEY'] = api_key
         client = Together()
 
-        # Format the prompt for chat
-        print("Prompt: ", prompt)
-        response = client.chat.completions.create(
-            model=self.model_name,
-            messages=[
-                {"role": "system", "content": prompt}
-            ],
-            stream=False,
-            response_format={"type": "json_object"},
-            temperature=self.temperature,
-        )
+        request: dict[str, Any] = {
+            "model": self.model_name,
+            "messages": [{"role": "system", "content": prompt}],
+            "stream": False,
+            "temperature": self.temperature,
+        }
+        if self.max_tokens is not None:
+            request["max_tokens"] = self.max_tokens
+        if self.response_format is not None:
+            request["response_format"] = self.response_format
+
+        response = client.chat.completions.create(**request)
         output = response.choices[0].message.content
-        print("Output: ", output)
         return output
 
     @property

--- a/langchain_agents/example_usage.py
+++ b/langchain_agents/example_usage.py
@@ -5,7 +5,10 @@ import logging
 from typing import Optional
 import toml
 import PyPDF2
-from agent import JobApplicationAgent
+try:
+    from .agent import JobApplicationAgent
+except ImportError:  # Allows running from langchain_agents/ directly
+    from agent import JobApplicationAgent
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, 
@@ -54,7 +57,7 @@ class ResumeProcessor:
 
             # Give the GitHub token
             response = await self.agent.process(f"This is my token {os.getenv('GITHUB_TOKEN')}")
-            logger.info(f"GitHub Token: {response}")
+            logger.info("GitHub token was provided to the agent")
 
             # Generate new README
             response = await self.agent.process("Generate a new GitHub README", 
@@ -93,7 +96,7 @@ class ResumeProcessor:
 
             # Give the GitHub token
             response = await self.agent.process(f"This is my token {os.getenv('GITHUB_TOKEN')}")
-            logger.info(f"GitHub Token: {response}")
+            logger.info("GitHub token was provided to the agent")
 
         except Exception as e:
             logger.error(f"Website operations failed: {str(e)}")

--- a/langchain_agents/streamlit_app.py
+++ b/langchain_agents/streamlit_app.py
@@ -1,7 +1,9 @@
 import streamlit as st
 import asyncio
-from agent import JobApplicationAgent
-import toml
+try:
+    from .agent import JobApplicationAgent
+except ImportError:  # Allows `streamlit run langchain_agents/streamlit_app.py`
+    from agent import JobApplicationAgent
 import os
 from typing import BinaryIO
 import pymupdf
@@ -15,13 +17,14 @@ from PIL import Image
 from streamlit.components.v1 import html
 import glob
 import shutil
+try:
+    from .config import get_secret
+except ImportError:  # Allows `streamlit run langchain_agents/streamlit_app.py`
+    from config import get_secret
 
 # Initialize environment variables and configurations
 try:
-    # save in secrets.toml in the root directory (not .streamlit)
-    secrets_path = Path(__file__).parent.parent / "secrets.toml"
-    secrets = toml.load(str(secrets_path))
-    os.environ['TOGETHER_API_KEY'] = secrets['TOGETHER_API_KEY']
+    os.environ['TOGETHER_API_KEY'] = get_secret('TOGETHER_API_KEY') or ""
 except Exception as e:
     st.error(f"Error loading secrets: {str(e)}")
     st.stop()
@@ -65,11 +68,11 @@ How can I help you?"""
         if 'profile_pic_base64' not in st.session_state:
             st.session_state.profile_pic_base64 = None
         
-        # Use the connection string directly instead of separate parameters
-        self.db_url = secrets['POSTGRES_DB']
+        self.db_url = get_secret('POSTGRES_DB', required=False)
         
-        # Initialize database table if it doesn't exist
-        self.initialize_database()
+        # Initialize database table if configured; feedback remains optional locally.
+        if self.db_url:
+            self.initialize_database()
         
         # Add a new session state variable to track submitted feedback
         if 'submitted_feedbacks' not in st.session_state:
@@ -104,6 +107,8 @@ How can I help you?"""
             
     def initialize_database(self):
         """Initialize the PostgreSQL database and create table if it doesn't exist."""
+        if not self.db_url:
+            return
         try:
             with psycopg2.connect(self.db_url) as conn:
                 with conn.cursor() as cur:
@@ -125,6 +130,9 @@ How can I help you?"""
 
     def save_feedback(self, feedback_data: dict):
         """Save feedback to PostgreSQL database."""
+        if not self.db_url:
+            st.info("Feedback database is not configured for this environment.")
+            return
         try:
             with psycopg2.connect(self.db_url) as conn:
                 with conn.cursor() as cur:

--- a/langchain_agents/tools.py
+++ b/langchain_agents/tools.py
@@ -1,15 +1,20 @@
 from langchain.tools import tool
 from typing import Optional, Dict, Any
-from custom_together_llm import TogetherLLM
 from github import Github
 from pydantic import BaseModel, Field
 import requests
 import json
 from bs4 import BeautifulSoup
 import random
-from agents.home_screen_generator import HomeScreenGenerator
 import os
-from agents.page_router import get_router, PageRouter
+try:
+    from .custom_together_llm import TogetherLLM
+    from .agents.home_screen_generator import HomeScreenGenerator
+    from .agents.page_router import get_router, PageRouter
+except ImportError:  # Allows running from langchain_agents/ directly
+    from custom_together_llm import TogetherLLM
+    from agents.home_screen_generator import HomeScreenGenerator
+    from agents.page_router import get_router, PageRouter
 
 def parse_resume(resume_content: str, llm: Optional[object] = None) -> str:
     """
@@ -46,6 +51,7 @@ def parse_resume(resume_content: str, llm: Optional[object] = None) -> str:
     }
     """
     
+    llm = llm or TogetherLLM(temperature=0.1, response_format={"type": "json_object"})
     return llm.invoke([
         {"role": "system", "content": parse_prompt},
         {"role": "user", "content": f"Parse this resume:\n\n{resume_content}"}
@@ -55,6 +61,7 @@ def get_github_profile(url: str, llm: Optional[object] = None) -> str:
     """
     Get GitHub profile content and parse it into a structured JSON format.
     """
+    llm = llm or TogetherLLM(temperature=0.1, response_format={"type": "json_object"})
     response = requests.get(url)
     soup = BeautifulSoup(response.text, 'html.parser')
     content = soup.find('article', class_='markdown-body entry-content container-lg f5')
@@ -136,7 +143,10 @@ def generate_website_content(query: Optional[str] = None, resume_content: Option
     # Parse resume if provided
     parsed_resume = None
     if isinstance(resume_content, str):
-        parsed_resume = parse_resume(resume_content, llm)
+        parsed_resume = parse_resume(
+            resume_content,
+            TogetherLLM(temperature=0.1, response_format={"type": "json_object"}),
+        )
         if json.loads(parsed_resume).get("ERROR") == "NOT ENOUGH INFORMATION":
             return "Not enough information to generate website content. Please provide the following information: " + json.loads(parsed_resume)["information_needed"]
 
@@ -332,12 +342,18 @@ def optimize_github_profile(url: str, resume_content: Optional[str] = None, llm:
     """
     llm = llm or TogetherLLM(temperature=0.1)
 
-    content = get_github_profile(url, llm)
+    content = get_github_profile(
+        url,
+        TogetherLLM(temperature=0.1, response_format={"type": "json_object"}),
+    )
     print(f"GitHub profile content: {content}")
         
     parsed_resume = None
     if isinstance(resume_content, str):
-        parsed_resume = parse_resume(resume_content, llm)
+        parsed_resume = parse_resume(
+            resume_content,
+            TogetherLLM(temperature=0.1, response_format={"type": "json_object"}),
+        )
         if json.loads(parsed_resume).get("ERROR") == "NOT ENOUGH INFORMATION":
             return "Not enough information to optimize profile. Please provide the following information: " + json.loads(parsed_resume)["information_needed"]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,35 @@
+import pytest
+
+from langchain_agents.config import ConfigurationError, get_secret, load_secrets
+
+
+def test_get_secret_prefers_environment_variable(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOGETHER_API_KEY", "from-env")
+    secrets_file = tmp_path / "secrets.toml"
+    secrets_file.write_text('TOGETHER_API_KEY = "from-file"\n')
+
+    assert get_secret("TOGETHER_API_KEY", secrets_path=secrets_file) == "from-env"
+
+
+def test_get_secret_reads_project_secrets_file_when_env_missing(tmp_path, monkeypatch):
+    monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+    secrets_file = tmp_path / "secrets.toml"
+    secrets_file.write_text('TOGETHER_API_KEY = "from-file"\n')
+
+    assert get_secret("TOGETHER_API_KEY", secrets_path=secrets_file) == "from-file"
+
+
+def test_load_secrets_missing_file_returns_empty_mapping(tmp_path):
+    assert load_secrets(tmp_path / "missing.toml") == {}
+
+
+def test_get_secret_raises_helpful_error_when_required_secret_missing(tmp_path, monkeypatch):
+    monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        get_secret("TOGETHER_API_KEY", secrets_path=tmp_path / "missing.toml")
+
+    message = str(exc_info.value)
+    assert "TOGETHER_API_KEY" in message
+    assert "environment variable" in message
+    assert "secrets.toml" in message


### PR DESCRIPTION
## Summary
- Add a reusable configuration helper that loads secrets from environment variables first, with secrets.toml fallback
- Make the Streamlit app usable without a mandatory Postgres feedback database in local/dev environments
- Package langchain_agents and make imports work both as a package and when running scripts directly
- Remove verbose LLM prompt/output logging and preserve JSON mode only for JSON-dependent agent/parser paths
- Add unit tests for secret-loading behavior and document env-var setup

## Test Plan
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q langchain_agents
- [x] git diff --cached --check
- [x] independent code review passed